### PR TITLE
make `vegam` public

### DIFF
--- a/server.go
+++ b/server.go
@@ -34,7 +34,7 @@ func marshal(data interface{}) []byte {
 	}
 	return marshaledData
 }
-func updateHandler(v *vegam) func(w http.ResponseWriter, r *http.Request) {
+func updateHandler(v *Vegam) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var peers UpdateRequest
 		defer r.Body.Close()
@@ -63,7 +63,7 @@ func updateHandler(v *vegam) func(w http.ResponseWriter, r *http.Request) {
 	}
 
 }
-func ListenServer(v *vegam, port string) error {
+func ListenServer(v *Vegam, port string) error {
 	http.HandleFunc("/update", updateHandler(v))
 	return http.ListenAndServe(port, nil)
 }

--- a/vegam.go
+++ b/vegam.go
@@ -20,7 +20,7 @@ import (
 	"github.com/weaveworks/mesh"
 )
 
-type vegam struct {
+type Vegam struct {
 	gossip  mesh.Gossip
 	peer    *peer
 	router  *mesh.Router
@@ -29,7 +29,7 @@ type vegam struct {
 	stop    chan int
 }
 
-func NewVegam(vc *VegamConfig) (*vegam, error) {
+func NewVegam(vc *VegamConfig) (*Vegam, error) {
 	initConfig(vc)
 	peername, err := mesh.PeerNameFromString(vc.PeerName)
 	if err != nil {
@@ -61,7 +61,7 @@ func NewVegam(vc *VegamConfig) (*vegam, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &vegam{
+	return &Vegam{
 		gossip: gossip,
 		peer:   peer,
 		router: router,
@@ -70,7 +70,7 @@ func NewVegam(vc *VegamConfig) (*vegam, error) {
 	}, nil
 }
 
-func (v *vegam) Start() {
+func (v *Vegam) Start() {
 	actions := make(chan func())
 	v.actions = actions
 	v.router.Start()
@@ -78,7 +78,7 @@ func (v *vegam) Start() {
 	go v.loop(actions)
 }
 
-func (v *vegam) loop(actions <-chan func()) {
+func (v *Vegam) loop(actions <-chan func()) {
 	for {
 		select {
 		case f := <-actions:
@@ -89,17 +89,17 @@ func (v *vegam) loop(actions <-chan func()) {
 	}
 }
 
-func (v *vegam) Stop() {
+func (v *Vegam) Stop() {
 	v.stop <- 1
 	v.router.Stop()
 }
 
-func (v *vegam) Get(key string) (val interface{}, exist bool) {
+func (v *Vegam) Get(key string) (val interface{}, exist bool) {
 	val, exist = v.peer.cache.get(key)
 	return
 }
 
-func (v *vegam) Put(key string, val interface{}, expiry time.Duration) {
+func (v *Vegam) Put(key string, val interface{}, expiry time.Duration) {
 	var expiryTime int64
 	if expiry == 0 {
 		expiryTime = 0


### PR DESCRIPTION
not sure if there would be objections to this change or not, but this was the reason I forked this repository. So I could do this sort of thing in my application:

```
type instance struct {
        <SNIP>
        cache      *vegamcache.Vegam
}
```

this allowed me when creating my gin router, to add vegamcache to my context eg:

```
        return func(c *gin.Context) {
                <SNIP>
                c.Set("cache", inst.cache)
                c.Next()
        }
```

this then allowed me to easily use vegamcache from my gin handlers 

```
func (inst *Instance) ListWorkFlows() (provClient.ProvWorkflows, error) {
        var provWorkflows provClient.ProvWorkflows
        provWorkflowsJson, exists := inst.cache.Get("ListWorkFlows")
        if exists {
```
I was recently going over my project I used my forked version of this project in again, and made me remember this so thought i'd mention it.